### PR TITLE
fix: cache idx passed to constructor

### DIFF
--- a/PyExpUtils/collection/Collector.py
+++ b/PyExpUtils/collection/Collector.py
@@ -64,6 +64,10 @@ class Collector:
         self._idxs = set[int]()
         self._keys = set[str]()
 
+        # if an idx is provided add it to the cache
+        if idx is not None:
+            self._idxs.add(idx)
+
     # -------------
     # -- Context --
     # -------------


### PR DESCRIPTION
Setting the index inside the Collector's constructor does not add it to `self._idxs` and causes `saveCollector` to skip saving the results. This pr adds the logic to conditionally add the `idx` to `self._idxs` if it is not `None`.

fixes #98