### PR TITLE
fix: allow account names for Vulcan server

### DIFF
--- a/PyExpUtils/runner/Slurm.py
+++ b/PyExpUtils/runner/Slurm.py
@@ -58,7 +58,7 @@ class MultiNodeOptions:
 # -- Validation --
 # ----------------
 def check_account(account: str):
-    assert account.startswith('rrg-') or account.startswith('def-')
+    assert account.startswith('rrg-') or account.startswith('def-') or account.startswith('aip-')
     assert not account.endswith('_cpu') and not account.endswith('_gpu')
 
 def check_time(time: str):


### PR DESCRIPTION
Vulcan account names start with `aip-`. This pr adds it to the assertion checks in `Slurm.py`.